### PR TITLE
Add executor widget

### DIFF
--- a/napari_bioimageio/_inference.py
+++ b/napari_bioimageio/_inference.py
@@ -1,0 +1,50 @@
+def run_inference(image: 'napari.types.ImageData',
+                  rdf_path: str,
+                  halo: int = 16) -> 'napari.types.LayerDataTuple':
+    """Run inference on a napari image using a bioimage.io model.
+
+    Parameters
+    ----------
+    image : napari.types.ImageData
+        Image to run inference on.
+    rdf_path : str
+        Path to the model RDF file.
+
+    Returns
+    -------
+    napari.types.LayerDataTuple
+        Inference result.
+    """
+    from bioimageio.core import (load_resource_description,
+                                 predict_with_tiling,
+                                 create_prediction_pipeline)
+    import xarray as xr
+
+    model_resource = load_resource_description(rdf_path)
+
+    prediction_pipeline = create_prediction_pipeline(
+        model_resource, devices=None, weight_format=None
+    )
+
+    tiling = {"tile": {"x": model_resource.inputs[0].shape[-1],
+                       "y": model_resource.inputs[0].shape[-2],
+                       "z": model_resource.inputs[0].shape[-3]},
+              "halo": {"x": halo, "y": halo}}
+
+    input_array = xr.DataArray(
+        image,
+        dims=tuple(model_resource.inputs[0].axes))
+
+    # run prediction and throw clear error message if dimensions don't match
+    prediction = predict_with_tiling(prediction_pipeline,
+                                        input_array,
+                                        tiling=tiling,
+                                        verbose=True)
+    properties = {
+        'name': 'prediction',
+        'colormap': 'inferno',
+        'blending': 'additive',
+        'opacity': 0.5
+        }
+
+    return (prediction, properties, 'image')


### PR DESCRIPTION
#108 

This adds a new action to the dropdown of the downloaded models in the ModelList of the bioimage.io widget. In essence, it retrieves the doi from the downloaded rdf spec, spawns the predictor function as shown in [this notebook](https://github.com/bioimage-io/core-bioimage-io-python/blob/main/example/model_usage.ipynb), and wraps it with magicgui in a separate predictor widget.

I started working on this at the ome-ngff-Hackathon at the biovisioncenter last week and would be happy for some feedback on it.

Minor thoughts:

- The `predict_image` functions checks under the hood whether the image dimensions line up with what the model expects - including some singleton dimensions. I don't think a prediction should fail if a model expects, say, `[1x1xZxYxX]` and receives `[ZxYxX]`. Maybe missing singleton dimensions could be added under the hood?
- Threaded execution: Currently, the created function returns normally, but maybe it should use the `yield` statement to allow for threaded execution.
- Zarr-compatibility: For large image data, it may be worthwhile to chunk the data under the hood and run chunkwise to not have to deal with overflowing memory.

@lorenzocerrone @jdeschamps could be interesting for you? Would be interested in your thoughts - I will leave this as draft PR for now.